### PR TITLE
set enableMediaProjectionService to true on WebRTCModuleOptions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <application
       android:name=".MainApplication"
@@ -9,7 +11,9 @@
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
       android:theme="@style/AppTheme">
-      <activity
+        <service android:name="com.supersami.foregroundservice.ForegroundService" android:foregroundServiceType="mediaProjection" />
+        <service android:name="com.supersami.foregroundservice.ForegroundServiceTask" />
+        <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"

--- a/android/app/src/main/java/com/livekitreactnativemeet/MainApplication.kt
+++ b/android/app/src/main/java/com/livekitreactnativemeet/MainApplication.kt
@@ -12,7 +12,8 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.flipper.ReactNativeFlipper
 import com.facebook.soloader.SoLoader
 import com.livekit.reactnative.LiveKitReactNative
-import com.livekit.reactnative.audio.AudioType
+import com.oney.WebRTCModule.WebRTCModuleOptions
+
 
 class MainApplication : Application(), ReactApplication {
 
@@ -36,6 +37,8 @@ class MainApplication : Application(), ReactApplication {
     get() = getDefaultReactHost(this.applicationContext, reactNativeHost)
 
   override fun onCreate() {
+    val options = WebRTCModuleOptions.getInstance()
+    options.enableMediaProjectionService = true
     LiveKitReactNative.setup(this);
     super.onCreate()
     SoLoader.init(this, false)


### PR DESCRIPTION
### Problem
When first installing the app and then entering a room, screen share wouldn't actually publish the track. However on each subsequent load of the RoomPage it would work.

### Solution
Followed this guide and added the correct permissions and set `enableMediaProjectionService` to true on 1WebRTCModuleOptions`

https://github.com/react-native-webrtc/react-native-webrtc/blob/master/Documentation/AndroidInstallation.md#screen-sharing